### PR TITLE
Use run_tests.sh in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,55 +169,9 @@ jobs:
           restore-keys: |
             app_home_deps-${{ matrix.php-version }}-
             app_home_deps-
-      - name: "Initialize containers"
+      - name: "Run tests"
         run: |
-          .github/actions/init_containers-start.sh
-      - name: "Show versions"
-        run: |
-          .github/actions/init_show-versions.sh
-      - name: "Build dependencies / translations"
-        run: |
-          docker compose exec -T app .github/actions/init_build.sh
-      - name: "Install DB tests"
-        if: "${{ success() || failure() }}"
-        run: |
-          docker compose exec -T app .github/actions/test_install.sh
-      - name: "Update DB tests (from 0.85.5, not using utf8mb4)"
-        if: "${{ success() || failure() }}"
-        run: |
-          .github/actions/init_initialize-0.85.5-db.sh
-          docker compose exec -T app .github/actions/test_update-from-older-version.sh
-      - name: "Update DB tests (from 9.5, using utf8mb4)"
-        if: "${{ success() || failure() }}"
-        run: |
-          .github/actions/init_initialize-9.5-db.sh
-          docker compose exec -T app .github/actions/test_update-from-9.5.sh
-      - name: "PHPUnit tests"
-        if: "${{ success() || failure() }}"
-        run: |
-          docker compose exec -T app .github/actions/test_tests-phpunit.sh
-      - name: "Functional tests"
-        if: "${{ success() || failure() }}"
-        run: |
-          docker compose exec -T app .github/actions/test_tests-functional.sh
-      - name: "Cache tests"
-        if: "${{ success() || failure() }}"
-        run: |
-          docker compose exec -T app .github/actions/test_tests-cache.sh
-      - name: "LDAP tests"
-        if: "${{ success() || failure() }}"
-        run: |
-          .github/actions/init_initialize-ldap-fixtures.sh
-          docker compose exec -T app .github/actions/test_tests-ldap.sh
-      - name: "IMAP tests"
-        if: "${{ success() || failure() }}"
-        run: |
-          .github/actions/init_initialize-imap-fixtures.sh
-          docker compose exec -T app .github/actions/test_tests-imap.sh
-      - name: "Javascript tests"
-        if: "${{ success() || failure() }}"
-        run: |
-          docker compose exec -T app .github/actions/test_javascript.sh
+          tests/run_tests.sh --build install update phpunit functional cache ldap imap javascript
 
   e2e:
     # Do not run scheduled tests on tier repositories
@@ -247,28 +201,10 @@ jobs:
           restore-keys: |
             app_home_deps-8.3-
             app_home_deps-
-      - name: "Initialize containers"
-        run: |
-          .github/actions/init_containers-start.sh
-      - name: "Show versions"
-        run: |
-          .github/actions/init_show-versions.sh
-      - name: "Build dependencies / translations"
-        run: |
-          docker compose exec -T app .github/actions/init_build.sh
-      - name: "Install DB tests"
-        if: "${{ success() || failure() }}"
-        run: |
-          docker compose exec -T app .github/actions/test_install.sh
-      - name: "WEB tests"
-        if: "${{ success() || failure() }}"
-        run: |
-          docker compose exec -T app .github/actions/test_tests-web.sh
-      - name: "E2E tests"
-        if: "${{ success() || failure() }}"
+      - name: "Run tests"
         id: "e2e"
         run: |
-          docker compose exec -T app .github/actions/test_tests-e2e.sh
+          tests/run_tests.sh --build install web e2e
       - name: "Upload Cypress screenshots"
         if: "${{ failure() && steps.e2e.conclusion == 'failure' }}"
         uses: actions/upload-artifact@v4

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,47 @@
+stages:
+  - build
+  - test
+  - deploy
+
+build:
+  stage: build
+  image: docker:24.0
+  services:
+    - docker:24.0-dind
+  variables:
+    DOCKER_TLS_CERTDIR: ""
+  script:
+    - docker build -t glpi .
+
+# Run the application's test suite
+# Dependencies and translations are built with --build
+# The script cleans up containers automatically
+
+test:
+  stage: test
+  image: docker:24.0
+  services:
+    - docker:24.0-dind
+  variables:
+    DOCKER_TLS_CERTDIR: ""
+    COMPOSE_FILE: ".github/actions/docker-compose-app.yml:.github/actions/docker-compose-services.yml"
+    APPLICATION_ROOT: "$CI_PROJECT_DIR"
+    DB_IMAGE: "githubactions-mariadb:10.11"
+    PHP_IMAGE: "githubactions-php-apache:8.3"
+    UPDATE_FILES_ACL: "true"
+  script:
+    - tests/run_tests.sh --build install update phpunit functional cache ldap imap javascript
+  dependencies:
+    - build
+
+deploy:
+  stage: deploy
+  image: docker:24.0
+  services:
+    - docker:24.0-dind
+  variables:
+    DOCKER_TLS_CERTDIR: ""
+  script:
+    - echo "Deploying to production..."
+  only:
+    - main


### PR DESCRIPTION
## Summary
- streamline CI test execution using `tests/run_tests.sh`
- add build and deploy jobs in `.gitlab-ci.yml`

## Testing
- `npm test` *(fails: jest not found)*
- `tests/run_tests.sh --help`


------
https://chatgpt.com/codex/tasks/task_b_6852891161d8832da0af39def9093713